### PR TITLE
Salvando lógica do áudio em banco e melhoria de UI

### DIFF
--- a/app/src/main/java/com/recuperavc/App.kt
+++ b/app/src/main/java/com/recuperavc/App.kt
@@ -2,6 +2,12 @@ package com.recuperavc
 
 import android.app.Application
 import com.recuperavc.data.db.AppRoomDatabase
+import com.recuperavc.data.db.DbProvider
+import com.recuperavc.data.CurrentUser
+import com.recuperavc.models.User
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class App : Application() {
     override fun onCreate() {
@@ -9,5 +15,19 @@ class App : Application() {
         android.util.Log.d("AppInit", "before DB init")
         AppRoomDatabase.getInstance(applicationContext)
         android.util.Log.d("AppInit", "after DB init")
+        CoroutineScope(Dispatchers.IO).launch {
+            val db = DbProvider.db(applicationContext)
+            db.userDao().upsert(
+                User(
+                    id = CurrentUser.ID,
+                    login = "demo",
+                    password = "demo",
+                    email = "demo@example.com",
+                    wordsPerMinute = 0f,
+                    wordErrorRate = 0f,
+                    name = "Usuário Demo"
+                )
+            )
+        }
     }
 }

--- a/app/src/main/java/com/recuperavc/MainActivity.kt
+++ b/app/src/main/java/com/recuperavc/MainActivity.kt
@@ -4,9 +4,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import com.recuperavc.ui.main.MainScreen
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.recuperavc.ui.home.HomeScreen
+import com.recuperavc.ui.main.AudioAnalysisScreen
 import com.recuperavc.ui.main.MainScreenViewModel
 import com.recuperavc.ui.theme.WhisperCppDemoTheme
+
+enum class AppRoute { Home, AudioAnalysis }
 
 class MainActivity : ComponentActivity() {
     private val viewModel: MainScreenViewModel by viewModels { MainScreenViewModel.factory() }
@@ -15,7 +22,17 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             WhisperCppDemoTheme {
-                MainScreen(viewModel)
+                var route by remember { mutableStateOf(AppRoute.Home) }
+                when (route) {
+                    AppRoute.Home -> HomeScreen(
+                        onOpenAudioTest = { route = AppRoute.AudioAnalysis },
+                        onExit = { finishAffinity() }
+                    )
+                    AppRoute.AudioAnalysis -> AudioAnalysisScreen(
+                        viewModel = viewModel,
+                        onBack = { route = AppRoute.Home }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/recuperavc/dao/AudioReportDao.kt
+++ b/app/src/main/java/com/recuperavc/dao/AudioReportDao.kt
@@ -15,4 +15,7 @@ interface AudioReportDao {
     @Transaction
     @Query("SELECT * FROM AudioReport WHERE id = :reportId")
     fun observeWithFiles(reportId: UUID): Flow<AudioReportWithFiles?>
+
+    @Query("SELECT * FROM AudioReport WHERE fk_User_id = :userId")
+    fun observeForUser(userId: Int): Flow<List<AudioReport>>
 }

--- a/app/src/main/java/com/recuperavc/dao/CoherenceReportDao.kt
+++ b/app/src/main/java/com/recuperavc/dao/CoherenceReportDao.kt
@@ -15,4 +15,7 @@ interface CoherenceReportDao {
     @Transaction
     @Query("SELECT * FROM CoherenceReport WHERE id = :id")
     fun observeWithPhrases(id: UUID): Flow<CoherenceReportWithPhrases?>
+
+    @Query("SELECT * FROM CoherenceReport WHERE fk_User_id = :userId")
+    fun observeForUser(userId: Int): Flow<List<CoherenceReport>>
 }

--- a/app/src/main/java/com/recuperavc/dao/UserDao.kt
+++ b/app/src/main/java/com/recuperavc/dao/UserDao.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface UserDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun upsert(user: User)
-    @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun upsertAll(users: List<User>)
+    @Upsert suspend fun upsert(user: User)
+    @Upsert suspend fun upsertAll(users: List<User>)
     @Query("SELECT * FROM User WHERE id = :id") fun observeById(id: Int): Flow<User?>
     @Query("SELECT * FROM User") fun observeAll(): Flow<List<User>>
     @Query("DELETE FROM User WHERE id = :id") suspend fun delete(id: Int)

--- a/app/src/main/java/com/recuperavc/data/CurrentUser.kt
+++ b/app/src/main/java/com/recuperavc/data/CurrentUser.kt
@@ -1,0 +1,6 @@
+package com.recuperavc.data
+
+object CurrentUser {
+    const val ID: Int = 1
+}
+

--- a/app/src/main/java/com/recuperavc/library/PhraseManager.kt
+++ b/app/src/main/java/com/recuperavc/library/PhraseManager.kt
@@ -2,11 +2,12 @@ package com.recuperavc.library
 
 import android.content.Context
 import android.content.SharedPreferences
+import java.text.Normalizer
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 class PhraseManager(private val context: Context) {
-    private val preferences: SharedPreferences = context.getSharedPreferences("phrase_cooldown", Context.MODE_PRIVATE)
+    private val preferences: SharedPreferences = context.applicationContext.getSharedPreferences("phrase_cooldown", Context.MODE_PRIVATE)
     private val mutex = Mutex()
     
     private val cooldownHours = 1L // aqui fica o tempo que a frase não irá voltar, dá pra mudar o tempo
@@ -17,20 +18,18 @@ class PhraseManager(private val context: Context) {
     suspend fun getNextPhrase(tamanho: String = "curta"): String = mutex.withLock {
         val primaryPhrases = getAvailablePhrases(tamanho)
         val secondaryPhrases = getAvailablePhrases(if (tamanho == "curta") "media" else "curta")
-        
         val availablePhrases = primaryPhrases + secondaryPhrases
-        
         val selectedPhrase = if (availablePhrases.isEmpty()) {
-            getAllPhrases(tamanho).firstOrNull { it != lastUsedPhrase } 
-                ?: getAllPhrases(tamanho).random()
+            val allPrimary = getAllPhrases(tamanho)
+            val allSecondary = getAllPhrases(if (tamanho == "curta") "media" else "curta")
+            val all = allPrimary + allSecondary
+            all.minByOrNull { preferences.getLong(keyFor(it), 0L) } ?: allPrimary.random()
         } else {
-            availablePhrases.firstOrNull { it != lastUsedPhrase } 
+            availablePhrases.firstOrNull { it != lastUsedPhrase }
                 ?: availablePhrases.random()
         }
-        
         markPhraseAsUsed(selectedPhrase)
         lastUsedPhrase = selectedPhrase
-        
         return selectedPhrase
     }
     
@@ -45,7 +44,7 @@ class PhraseManager(private val context: Context) {
         val currentTime = System.currentTimeMillis()
         
         return allPhrases.filter { phrase ->
-            val lastUsedTime = preferences.getLong(phrase, 0L)
+            val lastUsedTime = preferences.getLong(keyFor(phrase), 0L)
             (currentTime - lastUsedTime) >= cooldownMillis
         }
     }
@@ -61,7 +60,12 @@ class PhraseManager(private val context: Context) {
     
     private fun markPhraseAsUsed(phrase: String) {
         preferences.edit()
-            .putLong(phrase, System.currentTimeMillis())
-            .apply()
+            .putLong(keyFor(phrase), System.currentTimeMillis())
+            .commit()
+    }
+
+    private fun keyFor(phrase: String): String {
+        val normalized = Normalizer.normalize(phrase, Normalizer.Form.NFKC)
+        return normalized.lowercase().trim().replace("\\s+".toRegex(), " ")
     }
 }

--- a/app/src/main/java/com/recuperavc/recorder/SilenceDetector.kt
+++ b/app/src/main/java/com/recuperavc/recorder/SilenceDetector.kt
@@ -5,7 +5,7 @@ import kotlin.math.sqrt
 
 class SilenceDetector(
     private val silenceThreshold: Double = 0.02,
-    private val silenceDurationMs: Long = 2000,
+    private val silenceDurationMs: Long = 5000,
     private val minRecordingDurationMs: Long = 800
 ) {
     private var silenceStartTime: Long = 0

--- a/app/src/main/java/com/recuperavc/ui/components/HistoryDialog.kt
+++ b/app/src/main/java/com/recuperavc/ui/components/HistoryDialog.kt
@@ -1,0 +1,69 @@
+package com.recuperavc.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.recuperavc.data.CurrentUser
+import com.recuperavc.data.db.DbProvider
+import com.recuperavc.ui.theme.GreenDark
+import com.recuperavc.ui.theme.OnBackground
+
+@Composable
+fun HistoryDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val db = remember(context) { DbProvider.db(context) }
+    val audioFiles by db.audioFileDao().observeForUser(CurrentUser.ID).collectAsState(initial = emptyList())
+    val audioReports by db.audioReportDao().observeForUser(CurrentUser.ID).collectAsState(initial = emptyList())
+    val coherenceReports by db.coherenceReportDao().observeForUser(CurrentUser.ID).collectAsState(initial = emptyList())
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(onClick = onDismiss, colors = ButtonDefaults.buttonColors(containerColor = GreenDark)) { Text("Fechar", color = Color.White) }
+        },
+        title = { Text("Registros Salvos", color = Color.Black) },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth().heightIn(min = 100.dp, max = 480.dp).verticalScroll(rememberScrollState())) {
+                Text("Arquivos de Áudio (${audioFiles.size})", fontWeight = FontWeight.Bold, color = OnBackground)
+                Spacer(Modifier.height(8.dp))
+                audioFiles.take(10).forEach {
+                    val local = java.time.LocalDateTime.ofInstant(it.recordedAt, java.time.ZoneId.systemDefault())
+                    val formatted = local.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"))
+                    Text("• ${it.fileName} • ${formatted}", fontSize = 12.sp, color = Color.Black)
+                }
+                Spacer(Modifier.height(16.dp))
+                Text("Relatórios de Áudio (${audioReports.size})", fontWeight = FontWeight.Bold, color = OnBackground)
+                Spacer(Modifier.height(8.dp))
+                audioReports.take(10).forEach {
+                    Text("• ${it.description}", fontSize = 12.sp, color = Color.Black)
+                }
+                Spacer(Modifier.height(16.dp))
+                Text("Relatórios de Coerência (${coherenceReports.size})", fontWeight = FontWeight.Bold, color = OnBackground)
+                Spacer(Modifier.height(8.dp))
+                coherenceReports.take(10).forEach {
+                    Text("• score=${it.score} • ${it.description}", fontSize = 12.sp, color = Color.Black)
+                }
+            }
+        },
+        containerColor = Color.White
+    )
+}
+

--- a/app/src/main/java/com/recuperavc/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/home/HomeScreen.kt
@@ -1,0 +1,229 @@
+package com.recuperavc.ui.home
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Gesture
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Summarize
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.DrawerDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
+import com.recuperavc.ui.components.HistoryDialog
+import com.recuperavc.ui.theme.BackgroundGreen
+import com.recuperavc.ui.theme.GreenDark
+import com.recuperavc.ui.theme.GreenLight
+import com.recuperavc.ui.theme.OnBackground
+
+@Composable
+fun HomeScreen(onOpenAudioTest: () -> Unit, onExit: () -> Unit) {
+    val drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed)
+    var showReports by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            ModalDrawerSheet(
+                modifier = Modifier.fillMaxWidth(0.78f),
+                drawerContainerColor = GreenLight,
+                drawerContentColor = Color.White
+            ) {
+                Box(modifier = Modifier.fillMaxWidth().height(140.dp)) {
+                    Canvas(modifier = Modifier.fillMaxSize()) {
+                        val w = size.width
+                        val h = size.height
+                        val path = Path().apply {
+                            moveTo(0f, 0f)
+                            lineTo(0f, h * 0.55f)
+                            cubicTo(w * 0.25f, h * 0.20f, w * 0.55f, h * 0.95f, w * 0.80f, h * 0.60f)
+                            cubicTo(w * 0.90f, h * 0.40f, w, h * 0.48f, w, h * 0.38f)
+                            lineTo(w, 0f)
+                            close()
+                        }
+                        drawPath(path, color = GreenDark)
+                    }
+                }
+                Spacer(Modifier.height(32.dp))
+                NavigationDrawerItem(
+                    label = { Text("Relatórios") },
+                    selected = false,
+                    onClick = {
+                        showReports = true
+                    },
+                    icon = { Icon(Icons.Default.Summarize, contentDescription = null) },
+                    colors = NavigationDrawerItemDefaults.colors(
+                        selectedContainerColor = Color.White.copy(alpha = 0.16f),
+                        unselectedContainerColor = Color.Transparent,
+                        selectedTextColor = Color.White,
+                        unselectedTextColor = Color.White,
+                        selectedIconColor = Color.White,
+                        unselectedIconColor = Color.White
+                    )
+                )
+                NavigationDrawerItem(
+                    label = { Text("Preferências do App") },
+                    selected = false,
+                    onClick = {},
+                    icon = { Icon(Icons.Default.Settings, contentDescription = null) },
+                    colors = NavigationDrawerItemDefaults.colors(
+                        selectedContainerColor = Color.White.copy(alpha = 0.16f),
+                        unselectedContainerColor = Color.Transparent,
+                        selectedTextColor = Color.White,
+                        unselectedTextColor = Color.White,
+                        selectedIconColor = Color.White,
+                        unselectedIconColor = Color.White
+                    )
+                )
+                NavigationDrawerItem(
+                    label = { Text("Editar Perfil") },
+                    selected = false,
+                    onClick = {},
+                    icon = { Icon(Icons.Default.AccountCircle, contentDescription = null) },
+                    colors = NavigationDrawerItemDefaults.colors(
+                        selectedContainerColor = Color.White.copy(alpha = 0.16f),
+                        unselectedContainerColor = Color.Transparent,
+                        selectedTextColor = Color.White,
+                        unselectedTextColor = Color.White,
+                        selectedIconColor = Color.White,
+                        unselectedIconColor = Color.White
+                    )
+                )
+            }
+        }
+    ) {
+        Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
+            Box(modifier = Modifier.fillMaxWidth().height(160.dp)) {
+                Canvas(modifier = Modifier.fillMaxSize()) {
+                    val w = size.width
+                    val h = size.height
+                    val path = Path().apply {
+                        moveTo(0f, 0f)
+                        lineTo(0f, h * 0.55f)
+                        cubicTo(w * 0.25f, h * 0.25f, w * 0.45f, h * 0.95f, w * 0.6f, h * 0.65f)
+                        cubicTo(w * 0.8f, h * 0.35f, w * 0.9f, h * 0.5f, w, h * 0.4f)
+                        lineTo(w, 0f)
+                        close()
+                    }
+                    drawPath(path, color = GreenLight)
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                        Icon(Icons.Default.Menu, contentDescription = null, tint = OnBackground)
+                    }
+                    IconButton(onClick = onExit) {
+                        Icon(Icons.Default.Close, contentDescription = null, tint = OnBackground)
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier.fillMaxSize().padding(top = 140.dp, start = 16.dp, end = 16.dp, bottom = 16.dp),
+                verticalArrangement = Arrangement.Top,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ActionCard(
+                    title = "Teste de raciocínio",
+                    icon = Icons.Default.Psychology,
+                    onClick = {}
+                )
+                Spacer(Modifier.height(16.dp))
+                ActionCard(
+                    title = "Teste de reconhecimento de voz",
+                    icon = Icons.Default.Mic,
+                    onClick = onOpenAudioTest
+                )
+                Spacer(Modifier.height(16.dp))
+                ActionCard(
+                    title = "Teste de coordenação motora",
+                    icon = Icons.Default.Gesture,
+                    onClick = {}
+                )
+            }
+
+            if (showReports) {
+                HistoryDialog(onDismiss = { showReports = false })
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionCard(title: String, icon: androidx.compose.ui.graphics.vector.ImageVector, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().height(96.dp).clickable { onClick() },
+        colors = CardDefaults.cardColors(containerColor = GreenLight.copy(alpha = 0.9f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier.size(64.dp).clip(RoundedCornerShape(12.dp)).background(GreenDark),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(32.dp))
+            }
+            Spacer(Modifier.width(16.dp))
+            Text(
+                text = title,
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Start
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/recuperavc/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/MainScreen.kt
@@ -2,16 +2,15 @@ package com.recuperavc.ui.main
 
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material.icons.filled.Cancel
@@ -25,7 +24,7 @@ import androidx.compose.ui.geometry.center
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.animation.core.LinearEasing
+ 
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -77,12 +76,18 @@ private fun MainScreenContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                brush = Brush.radialGradient(
-                    colors = listOf(GreenLight, GreenPrimary, BackgroundGreen),
-                    radius = 1200f
-                )
-            )
+            .let { base ->
+                if (isLoading || isProcessing) {
+                    base.background(BackgroundGreen)
+                } else {
+                    base.background(
+                        brush = Brush.radialGradient(
+                            colors = listOf(GreenLight, GreenPrimary, BackgroundGreen),
+                            radius = 1200f
+                        )
+                    )
+                }
+            }
     ) {
         IconButton(
             onClick = { },
@@ -186,6 +191,36 @@ private fun MainScreenContent(
 
         }
         
+        if (isProcessing) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.35f))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = { }
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(64.dp),
+                        color = OnBackground,
+                        strokeWidth = 6.dp
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Analisando sua gravação...",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = OnBackground,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+
         if ((transcriptionResult.isNotEmpty() || analysisResult != null) && !isProcessing) {
             Box(
                 modifier = Modifier
@@ -276,16 +311,6 @@ private fun RecordingCircles(
             repeatMode = RepeatMode.Reverse
         ),
         label = "pulse_scale"
-    )
-    
-    val loadingRotation by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 360f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1000, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "loading_rotation"
     )
 
     Box(
@@ -382,28 +407,6 @@ private fun RecordingCircles(
             contentAlignment = Alignment.Center
         ) {
             when {
-                isProcessing -> {
-                    Box(
-                        modifier = Modifier.size(48.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(40.dp),
-                            color = OnSurface,
-                            strokeWidth = 4.dp
-                        )
-                        Icon(
-                            imageVector = Icons.Default.Mic,
-                            contentDescription = "Processando",
-                            tint = OnSurface.copy(alpha = 0.6f),
-                            modifier = Modifier
-                                .size(24.dp)
-                                .graphicsLayer {
-                                    rotationZ = loadingRotation
-                                }
-                        )
-                    }
-                }
                 isRecording -> {
                     Icon(
                         imageVector = Icons.Default.Mic,


### PR DESCRIPTION
Alterei o símbolo de carregamento pra spinner e é necessário ativar no modo dev de depuração as animações do android, se não, o próprio android esconde as animações. Implementado também a parte de salvar os resultados e o áudio analisado pelo whisper em banco, eu incrementei no App.kt um usuário padrão pois é necessário vincular a ele os resultado, obviamente. Dentro do UserDAO eu fiz uma alteração no @Insert(onConflict = REPLACE) para @Upsert, evitando delete em cascata dos filhos ao atualizar o usuário, pq toda vez que eu fechava o app e abria dnv ele criava um usuário novo