### PR TITLE
Alteração no salvamento de relatório de áudio

### DIFF
--- a/app/src/main/java/com/recuperavc/dao/AudioReportDao.kt
+++ b/app/src/main/java/com/recuperavc/dao/AudioReportDao.kt
@@ -18,4 +18,12 @@ interface AudioReportDao {
 
     @Query("SELECT * FROM AudioReport WHERE fk_User_id = :userId")
     fun observeForUser(userId: Int): Flow<List<AudioReport>>
+
+    @Transaction
+    suspend fun insertWithFiles(report: AudioReport, fileIds: List<UUID>) {
+        upsert(report)
+        fileIds.forEach { fid ->
+            link(AudioReportGroup(idAudioReport = report.id, idAudioFile = fid))
+        }
+    }
 }

--- a/app/src/main/java/com/recuperavc/dao/PatternDaos.kt
+++ b/app/src/main/java/com/recuperavc/dao/PatternDaos.kt
@@ -3,6 +3,7 @@ package com.recuperavc.dao
 import androidx.room.*
 import androidx.room.OnConflictStrategy.Companion.REPLACE
 import com.recuperavc.models.Phrase
+import com.recuperavc.models.enums.PhraseType
 import java.util.UUID
 
 @Dao
@@ -15,4 +16,7 @@ interface PhraseDao {
 
     @Query("SELECT * FROM Phrase WHERE id = :id")
     suspend fun getById(id: UUID): Phrase?
+
+    @Query("SELECT * FROM Phrase WHERE type = :type")
+    suspend fun getByType(type: PhraseType): List<Phrase>
 }


### PR DESCRIPTION
O contador de sessão mostra Sessão: X/3 mínimo. - O botão de salvar só habilita quando X >= 3. O usuário pode continuar além de 3; as médias considerarão todas as tentativas da sessão. Ao finalizar (ou ao voltar com X >= 3): -Calcula médias de WPM/WER; Cria um AudioReport com essas médias e define mainAudioFileId como o primeiro áudio da sessão; Insere na AudioReportGroup um vínculo para cada AudioFile gravado na sessão; Mostra a tela de resumo do relatório com WPM médio, Precisão média; Lista de tentativas com frase, WPM e Precisão de cada uma. - Se o usuário sair antes de 3, aparece o aviso e não é salvo nenhum AudioReport