### PR TITLE
Corrigindo a estrutura de salvamento do CoherenceReport e também adicionando o mesmo na página de relatórios

### DIFF
--- a/app/src/main/java/com/recuperavc/MainActivity.kt
+++ b/app/src/main/java/com/recuperavc/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.setValue
 import com.recuperavc.ui.home.HomeScreen
 import com.recuperavc.ui.main.AudioAnalysisScreen
 import com.recuperavc.ui.main.MainScreenViewModel
-import com.recuperavc.ui.main.SentenceArrangeScreen
 import com.recuperavc.ui.main.MotionTestScreen
 import com.recuperavc.ui.main.ReportsScreen
 import com.recuperavc.ui.settings.SettingsScreen

--- a/app/src/main/java/com/recuperavc/dao/CoherenceReportDao.kt
+++ b/app/src/main/java/com/recuperavc/dao/CoherenceReportDao.kt
@@ -11,7 +11,6 @@ import java.util.UUID
 interface CoherenceReportDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun upsert(report: CoherenceReport)
     @Insert(onConflict = OnConflictStrategy.IGNORE) suspend fun link(group: CoherenceReportGroup)
-    @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun insert(report: CoherenceReport)
 
     @Transaction
     @Query("SELECT * FROM CoherenceReport WHERE id = :id")

--- a/app/src/main/java/com/recuperavc/data/db/AppRoomDatabase.kt
+++ b/app/src/main/java/com/recuperavc/data/db/AppRoomDatabase.kt
@@ -50,7 +50,7 @@ abstract class AppRoomDatabase : RoomDatabase() {
                     AppRoomDatabase::class.java,
                     "app.db"
                 )
-                    .fallbackToDestructiveMigration() // <- só ativar isso aqui para ele limpar sozinho tudo do db se mudar o schema
+                    //.fallbackToDestructiveMigration() // <- só ativar isso aqui para ele limpar sozinho tudo do db se mudar o schema
                     .build()
                     .also { INSTANCE = it }
             }


### PR DESCRIPTION
Reestruturado o teste de coherence, a tabela de frase voltou ao que já era, eu não alterei o schema do Room. No teste de raciocínio é mantido a mesma frase até o usuário acertar, pra ficar de acordo com o tries e avgTries, também é salvo os detalhes das frases de 1 teste na coluna em json do  CoherenceReport. Troquei o salvamento por rodada por um upsert(report) + link, assim fica pareado com o que eu modelei no teste de voz. Eu recomendo vocês realizarem novos testes, testes no modelo antigo não irão puxar por conta de originalmente o Coherence não possuir nenhum tipo de vínculo de data em si, por isso eu coloquei no json da tabela um savedAtEpochMs, ele indica pra mim quando o relatório de raciocínio foi feito, diferente do teste de áudio que eu consigo pegar isso do recordedAt, o de Coherence não tinha nada referenciando data em si, aí adicionei isso pra poder ser filtrado no relatório, na coluna de json mesmo.