### PR TITLE
feat: add download report, title on main screen and bug fixes

### DIFF
--- a/app/schemas/com.recuperavc.data.db.AppRoomDatabase/7.json
+++ b/app/schemas/com.recuperavc.data.db.AppRoomDatabase/7.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 6,
+    "version": 7,
     "identityHash": "2a4bd4f342e6c820204fade3e4e7c376",
     "entities": [
       {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,15 @@
     <!-- Performance optimization permissions -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS"
+        tools:targetApi="33" />
     
     <!-- CPU and performance features -->
     <uses-feature android:name="android.hardware.type.embedded" android:required="false" />
@@ -22,6 +31,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.WhisperCppDemo"
         tools:targetApi="31">
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <activity
             android:name="com.recuperavc.MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/recuperavc/data/db/AppRoomDatabase.kt
+++ b/app/src/main/java/com/recuperavc/data/db/AppRoomDatabase.kt
@@ -30,7 +30,7 @@ import com.recuperavc.models.Phrase
         CoherenceReportGroup::class,
         MotionReport::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/recuperavc/models/CoherenceReport.kt
+++ b/app/src/main/java/com/recuperavc/models/CoherenceReport.kt
@@ -1,6 +1,8 @@
 package com.recuperavc.models
 
 import androidx.room.*
+import java.time.Instant
+import java.util.Date
 import java.util.UUID
 
 @Entity(
@@ -21,5 +23,6 @@ data class CoherenceReport(
     val averageErrorsPerTry: Float,
     val averageTimePerTry: Float,
     val allTestsDescription: String,
+    val date: Instant,
     @ColumnInfo(name = "fk_Phrase_id") val phraseId: UUID?
 )

--- a/app/src/main/java/com/recuperavc/ui/components/RecuperAVCBrandHeader.kt
+++ b/app/src/main/java/com/recuperavc/ui/components/RecuperAVCBrandHeader.kt
@@ -1,0 +1,94 @@
+package com.recuperavc.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.recuperavc.R
+import com.recuperavc.ui.theme.GreenAccent
+import com.recuperavc.ui.theme.GreenDark
+import com.recuperavc.ui.theme.GreenLight
+
+@Composable
+fun RecuperAVCBrandHeader() {
+    val textGradient = Brush.horizontalGradient(listOf(GreenDark, GreenLight))
+    val ribbonGradient = Brush.horizontalGradient(listOf(GreenLight, GreenDark))
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+
+            // ⬆️ Faixa superior com a frase (em vez do "pill")
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(36.dp)
+                    .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
+                    .background(ribbonGradient),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Recuperação guiada por dados",
+                    color = Color.White,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    letterSpacing = 0.5.sp
+                )
+            }
+
+            // Conteúdo do cabeçalho
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 18.dp, vertical = 14.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                val brand = buildAnnotatedString {
+                    withStyle(
+                        SpanStyle(
+                            brush = textGradient,
+                            fontWeight = FontWeight.ExtraBold,
+                            fontSize = 32.sp,
+                            letterSpacing = 0.5.sp
+                        )
+                    ) {
+                        append("Recuper")
+                        append("AVC")
+                    }
+                }
+                Text(text = brand, textAlign = TextAlign.Center, lineHeight = 34.sp)
+
+                Spacer(Modifier.height(6.dp))
+
+                Text(
+                    text = "Voz • Frases • Coordenação",
+                    color = GreenDark.copy(alpha = 0.75f),
+                    fontSize = 13.sp,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/recuperavc/ui/components/RecuperAVCBrandHeader.kt
+++ b/app/src/main/java/com/recuperavc/ui/components/RecuperAVCBrandHeader.kt
@@ -83,7 +83,7 @@ fun RecuperAVCBrandHeader() {
                 Spacer(Modifier.height(6.dp))
 
                 Text(
-                    text = "Voz • Frases • Coordenação",
+                    text = "Frases • Voz • Coordenação",
                     color = GreenDark.copy(alpha = 0.75f),
                     fontSize = 13.sp,
                     textAlign = TextAlign.Center

--- a/app/src/main/java/com/recuperavc/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/home/HomeScreen.kt
@@ -15,9 +15,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Gesture
+import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Psychology
@@ -53,6 +56,7 @@ import com.recuperavc.ui.theme.GreenLight
 import com.recuperavc.ui.theme.OnBackground
 import com.recuperavc.ui.sfx.Sfx
 import com.recuperavc.ui.sfx.rememberSfxController
+import com.recuperavc.ui.components.RecuperAVCBrandHeader
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -86,6 +90,7 @@ fun HomeScreen(
                 drawerContainerColor = GreenLight,
                 drawerContentColor = Color.White
             ) {
+                // Header wave
                 Box(modifier = Modifier.fillMaxWidth().height(100.dp)) {
                     Image(
                         painter = painterResource(id = R.drawable.wave_light),
@@ -102,7 +107,7 @@ fun HomeScreen(
                     onClick = {
                         navigateWithClick {
                             onOpenReports()
-                            // fechar o drawer após navegar é opcional; depende do seu NavHost
+                            // fechar o drawer após navegar é opcional, depende do seu NavHost
                             scope.launch { drawerState.close() }
                         }
                     },
@@ -136,6 +141,36 @@ fun HomeScreen(
                         unselectedIconColor = Color.White
                     )
                 )
+
+                Spacer(Modifier.weight(1f))
+                Divider(color = Color.White.copy(alpha = 0.2f))
+                NavigationDrawerItem(
+                    label = { Text("Sair") },
+                    selected = false,
+                    onClick = {
+                        navigateWithClick {
+                            onExit()
+                            scope.launch { drawerState.close() }
+                        }
+                    },
+                    icon = {
+                        Icon(
+                            Icons.Default.Logout,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp), // small icon
+                            tint = Color.White
+                        )
+                    },
+                    colors = NavigationDrawerItemDefaults.colors(
+                        selectedContainerColor = Color.White.copy(alpha = 0.12f),
+                        unselectedContainerColor = Color.Transparent,
+                        selectedTextColor = Color.White,
+                        unselectedTextColor = Color.White,
+                        selectedIconColor = Color.White,
+                        unselectedIconColor = Color.White
+                    )
+                )
+                Spacer(Modifier.height(8.dp))
             }
         }
     ) {
@@ -163,11 +198,6 @@ fun HomeScreen(
                     }) {
                         Icon(Icons.Default.Menu, contentDescription = null, tint = OnBackground)
                     }
-                    IconButton(onClick = {
-                        navigateWithClick(onExit)
-                    }) {
-                        Icon(Icons.Default.Close, contentDescription = null, tint = OnBackground)
-                    }
                 }
             }
 
@@ -178,6 +208,10 @@ fun HomeScreen(
                 verticalArrangement = Arrangement.Top,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                Spacer(Modifier.height(16.dp))
+                RecuperAVCBrandHeader()
+                Spacer(Modifier.height(58.dp))
+
                 ActionCard(
                     title = "Teste de raciocínio",
                     icon = Icons.Default.Psychology,
@@ -211,7 +245,10 @@ private fun ActionCard(
             .fillMaxWidth()
             .height(96.dp)
             .clickable { onClick() },
-        colors = CardDefaults.cardColors(containerColor = GreenLight.copy(alpha = 0.9f)),
+        colors = CardDefaults.cardColors(
+            containerColor = GreenLight,
+            contentColor = Color.White
+        ),
         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
         shape = RoundedCornerShape(12.dp)
     ) {

--- a/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
@@ -171,8 +171,9 @@ private fun AudioAnalysisContent(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.End,
+                .windowInsetsPadding(WindowInsets.statusBars) // evita notch/status bar
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically
         ) {
             BackButton(onBack)

--- a/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
@@ -4,10 +4,44 @@ import android.annotation.SuppressLint
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -33,11 +67,6 @@ import kotlin.math.roundToInt
 import kotlin.random.Random
 import com.recuperavc.ui.sfx.Sfx
 import com.recuperavc.ui.sfx.rememberSfxController
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 
 private enum class MotionMode { MOVING, STATIC }
 private enum class Hand { RIGHT, LEFT }
@@ -178,6 +207,28 @@ fun MotionTestScreen(
             }
         }
 
+        // ===== SETA VERDE NO PRÉ-TESTE (substitui o botão Voltar) =====
+        if (!testStarted && !finished) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(
+                    onClick = { sfx.play(Sfx.CLICK); onBack() }
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Voltar",
+                        tint = GreenDark
+                    )
+                }
+            }
+        }
+
         // TELA DE PRÉ-TESTE
         if (!testStarted && !finished) {
             Column(
@@ -283,14 +334,7 @@ fun MotionTestScreen(
                     modifier = Modifier.fillMaxWidth()
                 ) { Text("Começar teste", color = Color.White) }
 
-                Spacer(Modifier.height(12.dp))
-                OutlinedButton(
-                    onClick = {
-                        sfx.play(Sfx.CLICK) // feedback no voltar
-                        onBack()
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) { Text("Voltar") }
+                // (REMOVIDO) botão Outlined "Voltar" do pré-teste
             }
             return@BoxWithConstraints
         }
@@ -354,13 +398,13 @@ fun MotionTestScreen(
                     .fillMaxSize()
                     .background(Color.White)
             ) {
-                // Scrollable content
+                // Conteúdo com scroll
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(scrollState)
                         .padding(horizontal = 16.dp)
-                        // leave room for the bottom action bar so last items aren't behind it
+                        // deixa espaço pro action bar fixo
                         .padding(top = 16.dp, bottom = 96.dp),
                     verticalArrangement = Arrangement.Top,
                     horizontalAlignment = Alignment.CenterHorizontally
@@ -385,7 +429,7 @@ fun MotionTestScreen(
                     }
                 }
 
-                // Sticky bottom actions
+                // Barra de ações fixa no rodapé
                 Surface(
                     tonalElevation = 3.dp,
                     shadowElevation = 6.dp,
@@ -399,7 +443,7 @@ fun MotionTestScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(16.dp)
-                            // respect gesture nav / system bar insets
+                            // respeita os insets da navegação por gestos
                             .windowInsetsPadding(WindowInsets.navigationBars)
                     ) {
                         Button(

--- a/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
@@ -33,6 +33,11 @@ import kotlin.math.roundToInt
 import kotlin.random.Random
 import com.recuperavc.ui.sfx.Sfx
 import com.recuperavc.ui.sfx.rememberSfxController
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 
 private enum class MotionMode { MOVING, STATIC }
 private enum class Hand { RIGHT, LEFT }
@@ -342,57 +347,87 @@ fun MotionTestScreen(
 
         // RESULTADOS
         if (finished) {
-            Column(
+            val scrollState = rememberScrollState()
+
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.Top,
-                horizontalAlignment = Alignment.CenterHorizontally
+                    .background(Color.White)
             ) {
-                Text("Fim do teste!", fontSize = 22.sp, color = GreenDark)
-                Spacer(Modifier.height(12.dp))
+                // Scrollable content
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(scrollState)
+                        .padding(horizontal = 16.dp)
+                        // leave room for the bottom action bar so last items aren't behind it
+                        .padding(top = 16.dp, bottom = 96.dp),
+                    verticalArrangement = Arrangement.Top,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text("Fim do teste!", fontSize = 22.sp, color = GreenDark)
+                    Spacer(Modifier.height(12.dp))
 
-                lastReport?.let { report ->
-                    ReportCard(report)
-                    Spacer(Modifier.height(16.dp))
-                }
+                    lastReport?.let { report ->
+                        ReportCard(report)
+                        Spacer(Modifier.height(16.dp))
+                    }
 
-                Divider(thickness = 1.dp, color = Color(0xFFE0E0E0))
-                Spacer(Modifier.height(12.dp))
+                    Divider(thickness = 1.dp, color = Color(0xFFE0E0E0))
+                    Spacer(Modifier.height(12.dp))
 
-                if (history.isNotEmpty()) {
-                    Text("Relatórios recentes", fontSize = 18.sp, color = GreenDark)
-                    Spacer(Modifier.height(8.dp))
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        history.take(5).forEach { r -> SmallReportRow(r) }
+                    if (history.isNotEmpty()) {
+                        Text("Relatórios recentes", fontSize = 18.sp, color = GreenDark)
+                        Spacer(Modifier.height(8.dp))
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            history.take(5).forEach { r -> SmallReportRow(r) }
+                        }
                     }
                 }
 
-                Spacer(Modifier.height(24.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Button(
-                        onClick = {
-                            sfx.play(Sfx.CLICK)
-                            // Reset total para novo teste
-                            selectedHand = null
-                            isDominant = null
-                            chosenMode = null
-                            testStarted = false
-                            finished = false
-                            clicks = 0
-                            missedClicks = 0
-                            timeLeft = durationSecondsWithMovement
-                        },
-                        colors = ButtonDefaults.buttonColors(containerColor = GreenAccent)
-                    ) { Text("Novo teste", color = Color.White) }
+                // Sticky bottom actions
+                Surface(
+                    tonalElevation = 3.dp,
+                    shadowElevation = 6.dp,
+                    color = Color.White,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                            // respect gesture nav / system bar insets
+                            .windowInsetsPadding(WindowInsets.navigationBars)
+                    ) {
+                        Button(
+                            onClick = {
+                                sfx.play(Sfx.CLICK)
+                                // Reset total para novo teste
+                                selectedHand = null
+                                isDominant = null
+                                chosenMode = null
+                                testStarted = false
+                                finished = false
+                                clicks = 0
+                                missedClicks = 0
+                                timeLeft = durationSecondsWithMovement
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = GreenAccent),
+                            modifier = Modifier.weight(1f)
+                        ) { Text("Novo teste", color = Color.White) }
 
-                    Button(
-                        onClick = {
-                            sfx.play(Sfx.CLICK)
-                            onBack()
-                        },
-                        colors = ButtonDefaults.buttonColors(containerColor = GreenDark)
-                    ) { Text("Voltar", color = Color.White) }
+                        Button(
+                            onClick = {
+                                sfx.play(Sfx.CLICK)
+                                onBack()
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = GreenDark),
+                            modifier = Modifier.weight(1f)
+                        ) { Text("Voltar", color = Color.White) }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/recuperavc/ui/main/SentenceArrangeScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/SentenceArrangeScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -36,7 +35,6 @@ import com.recuperavc.models.CoherenceReport
 import com.recuperavc.models.CoherenceReportGroup
 import com.recuperavc.models.Phrase
 import kotlinx.coroutines.launch
-import java.util.UUID
 import kotlin.math.roundToInt
 import com.recuperavc.models.SettingsViewModel
 import com.recuperavc.ui.factory.SettingsViewModelFactory
@@ -55,6 +53,9 @@ private val ChipMint = Color(0xFFDDF7B5)
 private val ChipMintText = Color(0xFF2A3A13)
 private val CardTint = Color(0x1AFFFFFF)
 
+/* ------------------------- Constantes ---------------------------- */
+private const val MIN_REQUIRED = 3
+
 /* ------------------------- Dados ---------------------------- */
 data class CoherenceTry(val typedPhrase: String, val correct: Boolean, val elapsedMs: Long)
 data class RoundResult(
@@ -65,40 +66,114 @@ data class RoundResult(
     val tries: List<CoherenceTry>
 )
 
-/* ------------------------- Tela Multi Rodadas ---------------------------- */
+/* ------------------------- Multi-Rodadas com limite = tamanho da lista ---------------------------- */
 @Composable
 fun SentenceArrangeMultiRound(
     context: Context,
     phrases: List<Phrase>,
     sfx: com.recuperavc.ui.sfx.SfxController,
     onBack: () -> Unit = {},
-    onFinished: (List<RoundResult>) -> Unit,
+    onSave: (List<RoundResult>) -> Unit,
     viewModel: SettingsViewModel = viewModel(factory = SettingsViewModelFactory(LocalContext.current))
 ) {
-    val totalRounds = 3
-    var currentRound by rememberSaveable { mutableStateOf(0) }
+    val sessionLimit = phrases.size.coerceAtLeast(1) // garante >=1
+    var index by rememberSaveable { mutableStateOf(0) }
     val results = remember { mutableStateListOf<RoundResult>() }
+    var showEndDialog by remember { mutableStateOf(false) }
 
-    // System back → play once here
+    // Back físico → diálogo (sair antes do limite)
     BackHandler(enabled = true) {
         sfx.play(Sfx.CLICK)
-        onBack()
+        showEndDialog = true
+    }
+
+    if (showEndDialog) {
+        val count = results.size
+        AlertDialog(
+            onDismissRequest = {
+                sfx.play(Sfx.BUBBLE)
+                showEndDialog = false
+            },
+            confirmButton = {
+                Button(onClick = {
+                    sfx.play(Sfx.CLICK)
+                    if (count >= MIN_REQUIRED) {
+                        onSave(results.toList())
+                    } else {
+                        onBack()
+                    }
+                    showEndDialog = false
+                }) {
+                    Text(if (count >= MIN_REQUIRED) "Salvar e Sair" else "Descartar e Sair")
+                }
+            },
+            dismissButton = {
+                if (index < sessionLimit) {
+                    TextButton(onClick = {
+                        sfx.play(Sfx.CLICK)
+                        showEndDialog = false
+                    }) { Text("Continuar") }
+                }
+            },
+            title = { Text("Encerrar sessão") },
+            text = {
+                Text(
+                    if (results.size >= MIN_REQUIRED)
+                        "Você montou ${results.size} frases. Deseja salvar o relatório e sair?"
+                    else
+                        "Você montou ${results.size} de $MIN_REQUIRED frases mínimas. Se sair agora, os resultados não serão salvos."
+                )
+            }
+        )
+    }
+
+    val currentPhrase = phrases.getOrNull(index)
+    if (currentPhrase == null) {
+        // Falha defensiva; normalmente não chega aqui porque salvamos automaticamente ao atingir o limite
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Olive),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text("Não há mais frases nesta categoria.", color = Color.White)
+                Spacer(Modifier.height(12.dp))
+                Button(onClick = { sfx.play(Sfx.CLICK); onBack() }) {
+                    Text("Voltar")
+                }
+            }
+        }
+        return
     }
 
     SentenceArrangeScreen(
         context = context,
-        phraseEntity = phrases[currentRound],
-        round = currentRound + 1,
-        totalRounds = totalRounds,
+        phraseEntity = currentPhrase,
+        sessionCount = results.size,
+        sessionLimit = sessionLimit,
         sfx = sfx,
-        onResult = { result ->
-            results.add(result)
-            if (currentRound + 1 < totalRounds) currentRound++ else onFinished(results.toList())
+        canFinish = results.size >= MIN_REQUIRED,
+        onFinishRequested = {
+            sfx.play(Sfx.CLICK)
+            onSave(results.toList())
         },
-        onBack = { onBack() }
+        onResult = { result ->
+            // adiciona o resultado, avança índice e, se bateu no limite, salva automaticamente
+            results.add(result)
+            val nextIndex = index + 1
+            index = nextIndex
+            if (nextIndex >= sessionLimit) {
+                // atingiu o máximo de frases para a categoria → salva automaticamente
+                onSave(results.toList())
+            }
+        },
+        onBack = {
+            sfx.play(Sfx.CLICK)
+            showEndDialog = true
+        }
     )
 }
-
 
 /* ------------------------- Tela de Montar Frase ---------------------------- */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -107,21 +182,22 @@ fun SentenceArrangeScreen(
     context: Context,
     modifier: Modifier = Modifier,
     phraseEntity: Phrase,
-    round: Int,
-    totalRounds: Int,
+    sessionCount: Int,              // quantas concluídas
+    sessionLimit: Int,              // máximo permitido (tamanho da lista)
     sfx: com.recuperavc.ui.sfx.SfxController,
+    canFinish: Boolean,             // >= MIN_REQUIRED
+    onFinishRequested: () -> Unit,  // salvar & sair
     onResult: (RoundResult) -> Unit = {},
     onBack: () -> Unit = {}
 ) {
     val phrase = phraseEntity.description
-    val words = phrase.split(" ")
+    val words = remember(phrase) { phrase.split(" ") }
     var arrangedWords by rememberSaveable(phrase) { mutableStateOf(listOf<String>()) }
     var availableWords by rememberSaveable(phrase) { mutableStateOf(words.shuffled()) }
     var result by rememberSaveable { mutableStateOf<Boolean?>(null) }
     val startTime = remember(phrase) { System.currentTimeMillis() }
     val tries = remember(phrase) { mutableStateListOf<CoherenceTry>() }
 
-    // ===== Fundo verde atrás do Scaffold =====
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -131,10 +207,14 @@ fun SentenceArrangeScreen(
             containerColor = Color.Transparent,
             topBar = {
                 TopAppBar(
-                    title = { Text("Monte a frase ($round/$totalRounds)") },
+                    title = { Text("Monte a frase") },
                     navigationIcon = {
-                        IconButton(onClick = { sfx.play(Sfx.CLICK); onBack() }) {
-                            Icon(Icons.Default.ArrowBack, contentDescription = "Voltar", tint = Color.White)
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = androidx.compose.material.icons.Icons.Default.ArrowBack,
+                                contentDescription = "Voltar",
+                                tint = Color.White
+                            )
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
@@ -144,137 +224,183 @@ fun SentenceArrangeScreen(
                     )
                 )
             },
+            // sem FAB no Scaffold (vamos posicionar os botões dentro do conteúdo)
             bottomBar = {
-                BottomAppBar(
-                    containerColor = OliveDark,
-                    actions = {
-                        TextButton(onClick = {
-                            sfx.play(Sfx.CLICK)
-                            arrangedWords = listOf()
-                            availableWords = words.shuffled()
-                            result = null
-                        }) {
-                            Text("Limpar", color = Color.White)
-                        }
-                    },
-                    floatingActionButton = {
-                        val canProceed = arrangedWords.isNotEmpty()
-                        val buttonText = if (round == totalRounds) "Enviar" else "Verificar"
-
-                        ExtendedFloatingActionButton(
-                            onClick = {
-                                if (!canProceed) {
-                                    sfx.play(Sfx.WRONG_ANSWER)
-                                    return@ExtendedFloatingActionButton
-                                }
-                                sfx.play(Sfx.CLICK)
-
-                                val endTime = System.currentTimeMillis()
-                                val elapsed = endTime - startTime
-                                val typedPhrase = arrangedWords.joinToString(" ")
-                                val correct = typedPhrase == phrase
-                                result = correct
-                                tries.add(CoherenceTry(typedPhrase, correct, elapsed))
-
-                                if (correct) {
-                                    sfx.play(Sfx.RIGHT_ANSWER)
-                                    onResult(
-                                        RoundResult(
-                                            phraseId = phraseEntity.id,
-                                            typedPhrase = typedPhrase,
-                                            timeElapsed = elapsed,
-                                            correct = true,
-                                            tries = tries.toList()
-                                        )
-                                    )
-                                } else {
-                                    sfx.play(Sfx.WRONG_ANSWER)
-                                }
-                            },
-                            containerColor = ChipLime,
-                            contentColor = ChipLimeText,
-                            modifier = Modifier.alpha(if (canProceed) 1f else 0.45f)
-                        ) { Text(buttonText) }
-                    }
-                )
-            }
-        ) { padding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                Text(
-                    text = "Monte a frase:",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.White
-                )
-
-                // Área de frase montada
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(14.dp))
-                        .background(CardTint) // leve véu branco sobre o verde
-                        .padding(12.dp)
-                ) {
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.fillMaxWidth()
+                BottomAppBar(containerColor = OliveDark) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .windowInsetsPadding(WindowInsets.navigationBars)
+                            .padding(horizontal = 16.dp, vertical = 10.dp)
                     ) {
-                        if (arrangedWords.isEmpty()) {
-                            AssistiveHint()
-                        } else {
-                            arrangedWords.forEach { word ->
-                                WordChip(
-                                    text = word,
-                                    onClick = ({
-                                        arrangedWords = arrangedWords - word
-                                        availableWords = availableWords + word
-                                    }).withSfx(sfx, Sfx.CLICK),
-                                    shape = RoundedCornerShape(18.dp),
-                                    container = ChipMint,
-                                    content = ChipMintText
-                                )
-                            }
-                        }
-                    }
-
-                    AnimatedVisibility(
-                        visible = result != null,
-                        enter = fadeIn(),
-                        exit = fadeOut()
-                    ) {
-                        ResultMessageBox(isCorrect = result == true)
-                    }
-                }
-
-                Divider(color = Color.White.copy(alpha = .2f))
-
-                // Palavras disponíveis
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    availableWords.forEach { word ->
-                        WordChip(
-                            text = word,
-                            onClick = ({
-                                arrangedWords = arrangedWords + word
-                                availableWords = availableWords - word
-                            }).withSfx(sfx, Sfx.CLICK),
-                            shape = RoundedCornerShape(18.dp),
-                            container = ChipLime,
-                            content = ChipLimeText
+                        Text(
+                            text = "Sessão $sessionCount de $MIN_REQUIRED (mínimo)",
+                            color = Color.White.copy(alpha = 0.9f),
+                            style = MaterialTheme.typography.bodyMedium
                         )
                     }
                 }
+            }
+        ) { padding ->
+            // Conteúdo + camada de botões
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+            ) {
+                /* ======= CONTEÚDO PRINCIPAL ======= */
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text(
+                        text = "Monte a frase:",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = Color.White
+                    )
 
-                Spacer(Modifier.height(64.dp))
+                    // Área de frase montada
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(CardTint)
+                            .padding(12.dp)
+                    ) {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            if (arrangedWords.isEmpty()) {
+                                AssistiveHint()
+                            } else {
+                                arrangedWords.forEach { word ->
+                                    WordChip(
+                                        text = word,
+                                        onClick = ({
+                                            arrangedWords = arrangedWords - word
+                                            availableWords = availableWords + word
+                                        }).withSfx(sfx, Sfx.CLICK),
+                                        shape = RoundedCornerShape(18.dp),
+                                        container = ChipMint,
+                                        content = ChipMintText
+                                    )
+                                }
+                            }
+                        }
+
+                        AnimatedVisibility(
+                            visible = result != null,
+                            enter = fadeIn(),
+                            exit = fadeOut()
+                        ) {
+                            ResultMessageBox(isCorrect = result == true)
+                        }
+                    }
+
+                    Divider(color = Color.White.copy(alpha = .2f))
+
+                    // Palavras disponíveis
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        availableWords.forEach { word ->
+                            WordChip(
+                                text = word,
+                                onClick = ({
+                                    arrangedWords = arrangedWords + word
+                                    availableWords = availableWords - word
+                                }).withSfx(sfx, Sfx.CLICK),
+                                shape = RoundedCornerShape(18.dp),
+                                container = ChipLime,
+                                content = ChipLimeText
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(64.dp)) // respiro
+                }
+
+                /* ======= CAMADA DOS BOTÕES ======= */
+                val bottomOffset = 16.dp // evitar colisão com BottomAppBar
+
+                // LIMPAR — canto inferior esquerdo
+                TextButton(
+                    onClick = {
+                        sfx.play(Sfx.CLICK)
+                        arrangedWords = emptyList()
+                        availableWords = words.shuffled()
+                        result = null
+                    },
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(start = 16.dp, bottom = bottomOffset)
+                        .windowInsetsPadding(WindowInsets.navigationBars)
+                ) {
+                    Text("Limpar", color = Color.White)
+                }
+
+                // SALVAR TESTE — centro inferior (manual, fica visível com >= MIN_REQUIRED)
+                if (canFinish) {
+                    Button(
+                        onClick = onFinishRequested,
+                        colors = ButtonDefaults.buttonColors(containerColor = Color.White),
+                        shape = RoundedCornerShape(14.dp),
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = bottomOffset)
+                            .windowInsetsPadding(WindowInsets.navigationBars)
+                    ) {
+                        Text("Salvar Teste", color = OliveDark, fontWeight = FontWeight.Bold)
+                    }
+                }
+
+                // VERIFICAR — canto inferior direito
+                val canVerify = arrangedWords.isNotEmpty()
+                ExtendedFloatingActionButton(
+                    onClick = {
+                        if (!canVerify) {
+                            sfx.play(Sfx.WRONG_ANSWER)
+                        } else {
+                            sfx.play(Sfx.CLICK)
+
+                            val elapsed = System.currentTimeMillis() - startTime
+                            val typed = arrangedWords.joinToString(" ")
+                            val correct = typed == phrase
+                            result = correct
+                            tries.add(CoherenceTry(typed, correct, elapsed))
+
+                            if (correct) {
+                                sfx.play(Sfx.RIGHT_ANSWER)
+                                onResult(
+                                    RoundResult(
+                                        phraseId = phraseEntity.id,
+                                        typedPhrase = typed,
+                                        timeElapsed = elapsed,
+                                        correct = true,
+                                        tries = tries.toList()
+                                    )
+                                )
+                                arrangedWords = emptyList()
+                                availableWords = words.shuffled()
+                                result = null
+                            } else {
+                                sfx.play(Sfx.WRONG_ANSWER)
+                            }
+                        }
+                    },
+                    containerColor = ChipLime,
+                    contentColor = ChipLimeText,
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 16.dp, bottom = bottomOffset)
+                        .windowInsetsPadding(WindowInsets.navigationBars)
+                ) { Text("Verificar") }
             }
         }
     }
@@ -295,7 +421,7 @@ fun SentenceArrange(
 
     LaunchedEffect(Unit) {
         val db = DbProvider.db(context)
-        phrases = db.phraseDao().getAll()
+        phrases = db.phraseDao().getAll() // lista já filtrada pela categoria escolhida na navegação
     }
 
     if (showResults) {
@@ -305,7 +431,6 @@ fun SentenceArrange(
             results = results,
             sfx = sfx,
             onBackToHome = {
-                sfx.play(Sfx.CLICK)
                 onBackToHome()
             },
             onRestart = {
@@ -319,10 +444,8 @@ fun SentenceArrange(
             context = context,
             phrases = phrases,
             sfx = sfx,
-            onBack = {
-                onBackToHome()
-            },
-            onFinished = { finalResults ->
+            onBack = { onBackToHome() },
+            onSave = { finalResults ->
                 scope.launch(kotlinx.coroutines.Dispatchers.IO) {
                     val db = DbProvider.db(context)
                     val count = finalResults.size
@@ -515,7 +638,7 @@ fun SentenceResultScreen(
                     ) {
                         Column(modifier = Modifier.padding(12.dp)) {
                             Text(
-                                text = "Frase correta: ${phrases[idx]}",
+                                text = "Frase correta: ${phrases.getOrNull(idx) ?: "—"}",
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = Color.Black,
                                 fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/recuperavc/ui/main/SettingsScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.recuperavc.ui.settings
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -35,22 +36,18 @@ fun SettingsScreen(
     onApply: (darkMode: Boolean, contrast: Boolean, fontScale: Float) -> Unit = { _, _, _ -> }
 ) {
     val context = LocalContext.current
-    val viewModel: SettingsViewModel = viewModel(
-        factory = SettingsViewModelFactory(context)
-    )
-
+    val viewModel: SettingsViewModel = viewModel(factory = SettingsViewModelFactory(context))
     val sfx = rememberSfxController()
 
-    // Observando os estados do ViewModel
+    // Observe VM
     val darkMode by viewModel.darkModeFlow.collectAsState(initial = false)
     val contrast by viewModel.contrastFlow.collectAsState(initial = false)
     val sizeText by viewModel.sizeTextFlow.collectAsState(initial = 1.0f)
 
-    // Slider temporário
     var sliderValue by remember { mutableStateOf(sizeText) }
     LaunchedEffect(sizeText) { sliderValue = sizeText }
 
-    // Aplicando o tema responsivo
+    // Colors based on prefs
     val backgroundColor = when {
         contrast -> Color.Black
         darkMode -> Color(0xFF121212)
@@ -58,10 +55,22 @@ fun SettingsScreen(
     }
     val textColor = if (contrast || darkMode) Color.White else Color.Black
 
+    // Handle system back
+    BackHandler(enabled = true) {
+        sfx.play(Sfx.CLICK)
+        onBack()
+    }
+
+    val headerHeight = 160.dp
+
     Box(modifier = Modifier.fillMaxSize().background(backgroundColor)) {
 
-        // Header
-        Box(modifier = Modifier.fillMaxWidth().height(160.dp)) {
+        // HEADER (drawn at the very top)
+        Box(modifier = Modifier
+            .fillMaxWidth()
+            .height(headerHeight)
+        ) {
+            // Green wave-ish header
             Canvas(modifier = Modifier.fillMaxSize()) {
                 val w = size.width
                 val h = size.height
@@ -83,23 +92,31 @@ fun SettingsScreen(
                 }
                 drawPath(path, color = GreenLight)
             }
+
+            // Back arrow — same look as ReportsScreen
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.statusBars)
                     .padding(horizontal = 12.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.Start,
                 verticalAlignment = Alignment.Top
             ) {
                 IconButton(onClick = { sfx.play(Sfx.CLICK); onBack() }) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = null, tint = textColor)
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = null,
+                        tint = OnBackground
+                    )
                 }
             }
         }
 
+        // CONTENT — shifted *below* the header so it does not cover the arrow
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp)
+                .padding(top = headerHeight, start = 16.dp, end = 16.dp, bottom = 16.dp)
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -111,7 +128,7 @@ fun SettingsScreen(
             )
             Spacer(Modifier.height(16.dp))
 
-            // Card da aparência
+            // Aparência
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
@@ -150,7 +167,7 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(16.dp))
 
-            // Card de tamanho de texto
+            // Tamanho do texto
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
@@ -198,7 +215,7 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(16.dp))
 
-            // Texto de pré-visualização
+            // Pré-visualização
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
@@ -229,29 +246,19 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(24.dp))
 
-            // Footer
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                OutlinedButton(
-                    onClick = { sfx.play(Sfx.CLICK); onBack() },
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(12.dp)
-                ) {
-                    Text("Voltar", color = textColor)
-                }
-                Button(
-                    onClick = {
-                        sfx.play(Sfx.CLICK)
-                        viewModel.setDarkMode(darkMode)
-                        viewModel.setContrastText(contrast)
-                        viewModel.setSizeText(sizeText)
-                        onApply(darkMode, contrast, sizeText)
-                    },
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = GreenDark)
-                ) {
-                    Text("Aplicar", color = Color.White)
-                }
+            Button(
+                onClick = {
+                    sfx.play(Sfx.CLICK)
+                    viewModel.setDarkMode(darkMode)
+                    viewModel.setContrastText(contrast)
+                    viewModel.setSizeText(sizeText)
+                    onApply(darkMode, contrast, sizeText)
+                },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = GreenDark)
+            ) {
+                Text("Aplicar", color = Color.White)
             }
         }
     }

--- a/app/src/main/java/com/recuperavc/util/ExportNotification.kt
+++ b/app/src/main/java/com/recuperavc/util/ExportNotification.kt
@@ -1,0 +1,104 @@
+package com.recuperavc.util
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+
+object ExportNotification {
+
+    private const val CHANNEL_ID = "recuperavc_exports"
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "Exportações"
+            val desc = "Notificações de exportação de relatórios em PDF"
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = desc
+            }
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    private fun canPostNotifications(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= 33) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        } else true
+    }
+
+    /**
+     * Shows a notification "PDF salvo" that opens the viewer when tapped.
+     * pdfUri MUST be content:// (MediaStore or FileProvider).
+     */
+    fun notifyPdfSaved(context: Context, pdfUri: Uri, fileName: String) {
+        if (!canPostNotifications(context)) return
+
+        ensureChannel(context)
+
+        // Intent to view the PDF with read grant
+        val viewIntent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(pdfUri, "application/pdf")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+            clipData = ClipData.newRawUri("pdf", pdfUri)
+        }
+
+        val pendingFlags =
+            PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= 23) PendingIntent.FLAG_IMMUTABLE else 0
+
+        val contentPending = PendingIntent.getActivity(
+            context,
+            0,
+            viewIntent,
+            pendingFlags
+        )
+
+        val title = "PDF salvo"
+        val text = "Toque para abrir: $fileName"
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            // use your app icon; fully-qualified to avoid import issues
+            .setSmallIcon(android.R.drawable.stat_sys_download_done)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setAutoCancel(true)
+            .setContentIntent(contentPending)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+        // Optional: secondary "Compartilhar" action
+        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "application/pdf"
+            putExtra(Intent.EXTRA_STREAM, pdfUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            clipData = ClipData.newRawUri("pdf", pdfUri)
+        }
+        val sharePending = PendingIntent.getActivity(
+            context,
+            1,
+            Intent.createChooser(shareIntent, "Compartilhar PDF"),
+            pendingFlags
+        )
+        builder.addAction(
+            android.R.drawable.ic_menu_share,
+            "Compartilhar",
+            sharePending
+        )
+
+        val id = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
+        NotificationManagerCompat.from(context).notify(id, builder.build())
+    }
+}

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path
+        name="downloads_recuperavc"
+        path="Download/RecuperAVC/" />
+</paths>


### PR DESCRIPTION
- Adicionado som ao teste de frases;
- Adicionado som ao slider de configurações;
- Resolvido bug de tela preta/branca em teste de frases;
- Setas de retorno padronizadas em todas as telas;
- Fazer download dos relatórios atuais do app;
- Arrumar leve tom de verde ao redor das letras da tela principal;
- Remover o X de sair do app e colocar no menu lateral;
- Adicionar nome do app na tela inicial;
- Arrumar scroll na página final do teste de tapping;
- Adicionar coluna de data em todos os relatórios que precisam;
- Adicionado possibilidade do usuário fazer mais que 3 testes de frases;
- Adicionado um limite máximo de testes de frases para o usuário fazer (a quantidade existente máxima de frases na biblioteca);
- Adicionado dialog de aviso que o resultado não será salvo para o usuário se ele não fizer pelo menos 3 frases.