### PR TITLE
Bugs envolvendo o tema corrigido, telas de resultado padronizadas e melhoria de UX da tela de áudio

### DIFF
--- a/app/src/main/java/com/recuperavc/ui/components/ResultComponents.kt
+++ b/app/src/main/java/com/recuperavc/ui/components/ResultComponents.kt
@@ -1,0 +1,210 @@
+package com.recuperavc.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ResultDialogContainer(
+    appliedContrast: Boolean,
+    appliedDark: Boolean,
+    content: @Composable () -> Unit
+) {
+    val cardContainer = when {
+        appliedContrast -> Color.Black
+        appliedDark -> Color(0xFF1E1E1E)
+        else -> Color.White
+    }
+    val cardBorder = when {
+        appliedContrast -> BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+        appliedDark -> BorderStroke(1.dp, Color.White.copy(alpha = 0.1f))
+        else -> null
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.35f))
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+                .align(Alignment.Center),
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.cardColors(containerColor = cardContainer),
+            elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast || appliedDark) 0.dp else 6.dp),
+            border = cardBorder
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp)
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+fun ResultTitle(
+    text: String,
+    appliedContrast: Boolean,
+    appliedDark: Boolean,
+    appliedScale: Float,
+    accent: Color
+) {
+    val titleColor = when {
+        appliedContrast -> accent
+        appliedDark -> Color.White
+        else -> Color(0xFF1B1B1B)
+    }
+
+    Text(
+        text,
+        fontSize = 22.sp * appliedScale,
+        fontWeight = FontWeight.Bold,
+        color = titleColor
+    )
+}
+
+@Composable
+fun ResultMetricCard(
+    title: String,
+    value: String,
+    unit: String,
+    color: Color,
+    icon: ImageVector,
+    appliedContrast: Boolean,
+    appliedDark: Boolean,
+    appliedScale: Float
+) {
+    val container = when {
+        appliedContrast -> Color.Black
+        appliedDark -> Color(0xFF2A2A2A)
+        else -> Color.White.copy(alpha = 0.95f)
+    }
+    val border = when {
+        appliedContrast -> BorderStroke(2.dp, color)
+        appliedDark -> BorderStroke(1.dp, Color.White.copy(alpha = 0.1f))
+        else -> null
+    }
+    val titleColor = when {
+        appliedContrast -> Color.White.copy(alpha = 0.8f)
+        appliedDark -> Color(0xFFCCCCCC)
+        else -> Color.Gray.copy(alpha = 0.8f)
+    }
+    val valueColor = when {
+        appliedContrast -> Color.White
+        appliedDark -> Color.White
+        else -> color
+    }
+    val unitColor = when {
+        appliedContrast -> Color.White.copy(alpha = 0.7f)
+        appliedDark -> Color(0xFFCCCCCC)
+        else -> color.copy(alpha = 0.7f)
+    }
+
+    Card(
+        modifier = Modifier.width(140.dp),
+        colors = CardDefaults.cardColors(containerColor = container),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast || appliedDark) 0.dp else 8.dp),
+        border = border
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(24.dp))
+            Spacer(Modifier.height(8.dp))
+            Text(text = title, fontSize = 13.sp * appliedScale, fontWeight = FontWeight.Medium, color = titleColor)
+            Spacer(Modifier.height(6.dp))
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(text = value, fontSize = 26.sp * appliedScale, fontWeight = FontWeight.Bold, color = valueColor)
+                Text(text = " $unit", fontSize = 14.sp * appliedScale, fontWeight = FontWeight.Medium, color = unitColor)
+            }
+        }
+    }
+}
+
+@Composable
+fun ResultSectionLabel(
+    text: String,
+    appliedContrast: Boolean,
+    appliedDark: Boolean,
+    appliedScale: Float
+) {
+    val labelColor = when {
+        appliedContrast -> Color.White
+        appliedDark -> Color(0xFFEDEDED)
+        else -> Color(0xFF3A3A3A)
+    }
+
+    Text(text, fontWeight = FontWeight.SemiBold, fontSize = 16.sp * appliedScale, color = labelColor)
+}
+
+@Composable
+fun ResultItemCard(
+    appliedContrast: Boolean,
+    appliedDark: Boolean,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val itemCardContainer = when {
+        appliedContrast -> Color.Black
+        appliedDark -> Color(0xFF2A2A2A)
+        else -> Color(0xFFF5F5F5)
+    }
+    val itemBorder = when {
+        appliedContrast -> BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+        appliedDark -> BorderStroke(1.dp, Color.White.copy(alpha = 0.08f))
+        else -> null
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        colors = CardDefaults.cardColors(containerColor = itemCardContainer),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast || appliedDark) 0.dp else 1.dp),
+        border = itemBorder
+    ) {
+        Column(modifier = Modifier.padding(12.dp), content = content)
+    }
+}
+
+@Composable
+fun ResultItemText(
+    text: String,
+    appliedContrast: Boolean,
+    appliedDark: Boolean,
+    appliedScale: Float,
+    fontWeight: FontWeight = FontWeight.Medium,
+    fontSize: Float = 14f
+) {
+    val itemTextColor = when {
+        appliedContrast -> Color.White
+        appliedDark -> Color(0xFFEDEDED)
+        else -> Color(0xFF1B1B1B)
+    }
+
+    Text(text, fontWeight = fontWeight, fontSize = fontSize.sp * appliedScale, color = itemTextColor)
+}

--- a/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
@@ -65,6 +65,7 @@ import com.recuperavc.ui.theme.OnSurface
 import com.recuperavc.ui.util.InitialSettings
 import com.recuperavc.ui.util.PaintSystemBars
 import com.recuperavc.ui.util.rememberInitialSettings
+import com.recuperavc.ui.components.*
 import kotlinx.coroutines.flow.collectLatest
 
 private val HighContrastAccent = Color(0xFFFFD600)

--- a/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.activity.compose.BackHandler
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
@@ -111,6 +112,11 @@ fun AudioAnalysisScreen(
     )
 
     var showEndDialog by remember { mutableStateOf(false) }
+
+    BackHandler(enabled = true) {
+        sfx.play(Sfx.CLICK)
+        showEndDialog = true
+    }
 
     AudioAnalysisContent(
         canTranscribe = viewModel.canTranscribe,
@@ -579,19 +585,40 @@ private fun MetricCard(
     color: Color,
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     appliedContrast: Boolean,
-    appliedScale: Float
+    appliedScale: Float,
+    appliedDark: Boolean = false
 ) {
-    val container = if (appliedContrast) Color.Black else Color.White.copy(alpha = 0.95f)
-    val border = if (appliedContrast) BorderStroke(2.dp, color) else null
-    val titleColor = if (appliedContrast) Color.White.copy(alpha = 0.8f) else Color.Gray.copy(alpha = 0.8f)
-    val valueColor = if (appliedContrast) Color.White else color
-    val unitColor = if (appliedContrast) Color.White.copy(alpha = 0.7f) else color.copy(alpha = 0.7f)
+    val container = when {
+        appliedContrast -> Color.Black
+        appliedDark -> Color(0xFF2A2A2A)
+        else -> Color.White.copy(alpha = 0.95f)
+    }
+    val border = when {
+        appliedContrast -> BorderStroke(2.dp, color)
+        appliedDark -> BorderStroke(1.dp, Color.White.copy(alpha = 0.1f))
+        else -> null
+    }
+    val titleColor = when {
+        appliedContrast -> Color.White.copy(alpha = 0.8f)
+        appliedDark -> Color(0xFFCCCCCC)
+        else -> Color.Gray.copy(alpha = 0.8f)
+    }
+    val valueColor = when {
+        appliedContrast -> Color.White
+        appliedDark -> Color.White
+        else -> color
+    }
+    val unitColor = when {
+        appliedContrast -> Color.White.copy(alpha = 0.7f)
+        appliedDark -> Color(0xFFCCCCCC)
+        else -> color.copy(alpha = 0.7f)
+    }
 
     Card(
         modifier = Modifier.width(140.dp),
         colors = CardDefaults.cardColors(containerColor = container),
         shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast) 0.dp else 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast || appliedDark) 0.dp else 8.dp),
         border = border
     ) {
         Column(
@@ -623,6 +650,37 @@ private fun SessionSummaryScreen(
     onClose: () -> Unit,
     onNavigateHome: () -> Unit
 ) {
+    val cardContainer = when {
+        appliedContrast -> Color.Black
+        appliedDark -> Color(0xFF1E1E1E)
+        else -> Color.White
+    }
+    val titleColor = when {
+        appliedContrast -> accent
+        appliedDark -> Color.White
+        else -> Color(0xFF1B1B1B)
+    }
+    val labelColor = when {
+        appliedContrast -> Color.White
+        appliedDark -> Color(0xFFEDEDED)
+        else -> Color(0xFF3A3A3A)
+    }
+    val itemCardContainer = when {
+        appliedContrast -> Color.Black
+        appliedDark -> Color(0xFF2A2A2A)
+        else -> Color(0xFFF5F5F5)
+    }
+    val itemTextColor = when {
+        appliedContrast -> Color.White
+        appliedDark -> Color(0xFFEDEDED)
+        else -> Color(0xFF1B1B1B)
+    }
+    val cardBorder = when {
+        appliedContrast -> BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+        appliedDark -> BorderStroke(1.dp, Color.White.copy(alpha = 0.1f))
+        else -> null
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -634,8 +692,9 @@ private fun SessionSummaryScreen(
                 .padding(20.dp)
                 .align(Alignment.Center),
             shape = RoundedCornerShape(20.dp),
-            colors = CardDefaults.cardColors(containerColor = if (appliedContrast) Color.Black else Color.White),
-            elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast) 0.dp else 6.dp)
+            colors = CardDefaults.cardColors(containerColor = cardContainer),
+            elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast || appliedDark) 0.dp else 6.dp),
+            border = cardBorder
         ) {
             Column(
                 modifier = Modifier
@@ -648,7 +707,7 @@ private fun SessionSummaryScreen(
                     "Relatório do Teste",
                     fontSize = 22.sp * appliedScale,
                     fontWeight = FontWeight.Bold,
-                    color = if (appliedContrast) accent else textPrimary
+                    color = titleColor
                 )
                 Spacer(Modifier.height(16.dp))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
@@ -659,7 +718,8 @@ private fun SessionSummaryScreen(
                         color = accent,
                         icon = Icons.Default.Speed,
                         appliedContrast = appliedContrast,
-                        appliedScale = appliedScale
+                        appliedScale = appliedScale,
+                        appliedDark = appliedDark
                     )
                     MetricCard(
                         title = "Precisão média",
@@ -668,26 +728,25 @@ private fun SessionSummaryScreen(
                         color = accent,
                         icon = Icons.Default.TrendingUp,
                         appliedContrast = appliedContrast,
-                        appliedScale = appliedScale
+                        appliedScale = appliedScale,
+                        appliedDark = appliedDark
                     )
                 }
                 Spacer(Modifier.height(16.dp))
-                Text("Tentativas", fontWeight = FontWeight.SemiBold, color = textPrimary)
+                Text("Tentativas", fontWeight = FontWeight.SemiBold, color = labelColor)
                 Spacer(Modifier.height(8.dp))
                 summary.items.forEachIndexed { idx, item ->
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 4.dp),
-                        colors = CardDefaults.cardColors(
-                            containerColor = if (appliedContrast) Color.Black else Color.White.copy(alpha = 0.95f)
-                        ),
+                        colors = CardDefaults.cardColors(containerColor = itemCardContainer),
                         shape = RoundedCornerShape(12.dp),
-                        elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast) 0.dp else 1.dp),
-                        border = if (appliedContrast) BorderStroke(1.dp, Color.White.copy(alpha = 0.2f)) else null
+                        elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast || appliedDark) 0.dp else 1.dp),
+                        border = if (appliedContrast) BorderStroke(1.dp, Color.White.copy(alpha = 0.15f)) else if (appliedDark) BorderStroke(1.dp, Color.White.copy(alpha = 0.08f)) else null
                     ) {
                         Column(modifier = Modifier.padding(12.dp)) {
-                            Text("${idx + 1}. ${item.phrase}", fontWeight = FontWeight.Medium, color = textPrimary)
+                            Text("${idx + 1}. ${item.phrase}", fontWeight = FontWeight.Medium, color = itemTextColor)
                             Spacer(Modifier.height(6.dp))
                             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                                 Text("WPM: ${item.wpm}", color = accent)

--- a/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/AudioAnalysisScreen.kt
@@ -1,5 +1,10 @@
 package com.recuperavc.ui.main
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -19,7 +24,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.TrendingUp
@@ -385,6 +391,68 @@ private fun AudioAnalysisContent(
                     )
                 }
 
+                val chipContainer = when {
+                    appliedContrast -> Color.Black
+                    appliedDark -> Color(0xFF2A2A2A)
+                    else -> Color.White.copy(alpha = 0.96f)
+                }
+                val chipLabel = when {
+                    appliedContrast -> Color.White
+                    appliedDark -> Color(0xFFEDEDED)
+                    else -> Color(0xFF1B1B1B)
+                }
+                val chipBorder = when {
+                    appliedContrast -> BorderStroke(1.dp, accent.copy(alpha = 0.7f))
+                    appliedDark -> BorderStroke(1.dp, Color.White.copy(alpha = 0.10f))
+                    else -> null
+                }
+                val chipIconBg = when {
+                    appliedContrast -> accent
+                    appliedDark -> GreenDark
+                    else -> GreenDark
+                }
+                val chipIconTint = if (appliedContrast) Color.Black else Color.White
+                AnimatedVisibility(
+                    visible = isRecording && !isProcessing && !isCancelling,
+                    enter = fadeIn() + expandVertically(),
+                    exit = fadeOut() + shrinkVertically()
+                ) {
+                    Card(
+                        shape = RoundedCornerShape(50),
+                        colors = CardDefaults.cardColors(containerColor = chipContainer),
+                        elevation = CardDefaults.cardElevation(defaultElevation = if (appliedContrast || appliedDark) 0.dp else 3.dp),
+                        border = chipBorder,
+                        modifier = Modifier.padding(top = 12.dp, bottom = 12.dp)
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(20.dp)
+                                    .clip(CircleShape)
+                                    .background(chipIconBg),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Info,
+                                    contentDescription = null,
+                                    tint = chipIconTint,
+                                    modifier = Modifier.size(12.dp)
+                                )
+                            }
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = "Toque no botão grande novamente para enviar agora",
+                                fontSize = 14.sp * appliedScale,
+                                color = chipLabel
+                            )
+                        }
+                    }
+                }
+
                 Text(
                     text = phraseText,
                     fontSize = 24.sp * appliedScale,
@@ -425,14 +493,14 @@ private fun AudioAnalysisContent(
                                 contentColor = Color.White
                             ),
                             modifier = Modifier
-                                .size(56.dp)
+                                .size(64.dp)
                                 .align(Alignment.CenterHorizontally),
                             shape = CircleShape
                         ) {
                             Icon(
-                                imageVector = Icons.Default.Cancel,
+                                imageVector = Icons.Default.Close,
                                 contentDescription = "Cancelar gravação",
-                                modifier = Modifier.size(24.dp)
+                                modifier = Modifier.size(36.dp)
                             )
                         }
                     }

--- a/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
@@ -45,6 +45,9 @@ import com.recuperavc.ui.factory.SettingsViewModelFactory
 import com.recuperavc.ui.util.InitialSettings
 import com.recuperavc.ui.util.PaintSystemBars
 import com.recuperavc.ui.util.rememberInitialSettings
+import com.recuperavc.ui.components.*
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.TouchApp
 
 private enum class MotionMode { MOVING, STATIC }
 private enum class Hand { RIGHT, LEFT }
@@ -452,119 +455,26 @@ fun MotionTestScreen(
 
         // RESULTS
         if (finished) {
-            val scrollState = rememberScrollState()
-
-            val surfaceColor = when {
-                appliedContrast -> Color.Black
-                appliedDark -> Color(0xFF161717)
-                else -> Color.White
-            }
-            val cardColor = when {
-                appliedContrast -> Color.Black
-                appliedDark -> Color(0xFF1E1F1F)
-                else -> Color(0xFFF4F8F1)
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(surfaceColor)
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .verticalScroll(scrollState)
-                        .padding(horizontal = 16.dp)
-                        .padding(top = 16.dp, bottom = 96.dp),
-                    verticalArrangement = Arrangement.Top,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text("Fim do teste!", fontSize = (22.sp * appliedScale), color = textPrimary, fontWeight = FontWeight.SemiBold)
-                    Spacer(Modifier.height(12.dp))
-
-                    lastReport?.let { report ->
-                        ReportCard(
-                            report = report,
-                            container = cardColor,
-                            border = if (appliedContrast) BorderStroke(2.dp, HighContrastAccent) else null,
-                            titleColor = if (appliedContrast) HighContrastAccent else accentSolid,
-                            textPrimary = textPrimary,
-                            textSecondary = textSecondary,
-                            scale = appliedScale
-                        )
-                        Spacer(Modifier.height(16.dp))
-                    }
-
-                    Divider(thickness = 1.dp, color = dividerColor)
-                    Spacer(Modifier.height(12.dp))
-
-                    if (history.isNotEmpty()) {
-                        Text("Relatórios recentes", fontSize = (18.sp * appliedScale), color = textPrimary, fontWeight = FontWeight.Medium)
-                        Spacer(Modifier.height(8.dp))
-                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            history.take(5).forEach { r ->
-                                SmallReportRow(
-                                    report = r,
-                                    container = if (appliedContrast) Color.Black else if (appliedDark) Color(0xFF1C1D1D) else Color(0xFFFAFAFA),
-                                    border = if (appliedContrast) BorderStroke(1.dp, Color.White.copy(alpha = 0.2f)) else null,
-                                    textPrimary = textPrimary,
-                                    textSecondary = textSecondary,
-                                    scale = appliedScale
-                                )
-                            }
-                        }
-                    }
-                }
-
-                // Bottom actions
-                Surface(
-                    tonalElevation = if (appliedContrast) 0.dp else 3.dp,
-                    shadowElevation = if (appliedContrast) 0.dp else 6.dp,
-                    color = surfaceColor,
-                    border = if (appliedContrast) BorderStroke(1.dp, Color.White.copy(alpha = 0.2f)) else null,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .fillMaxWidth()
-                ) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp)
-                            .windowInsetsPadding(WindowInsets.navigationBars)
-                    ) {
-                        Button(
-                            onClick = {
-                                sfx.play(Sfx.CLICK)
-                                selectedHand = null
-                                isDominant = null
-                                chosenMode = null
-                                testStarted = false
-                                finished = false
-                                clicks = 0
-                                missedClicks = 0
-                                timeLeft = durationSecondsWithMovement
-                            },
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = accentAlt,
-                                contentColor = buttonFgOnAccent
-                            ),
-                            modifier = Modifier.weight(1f),
-                            shape = RoundedCornerShape(14.dp)
-                        ) { Text("Novo teste", color = buttonFgOnAccent, fontSize = (16.sp * appliedScale), fontWeight = FontWeight.SemiBold) }
-
-                        Button(
-                            onClick = { sfx.play(Sfx.CLICK); showEndDialog = true },
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = accentSolid,
-                                contentColor = buttonFgOnAccent
-                            ),
-                            modifier = Modifier.weight(1f),
-                            shape = RoundedCornerShape(14.dp)
-                        ) { Text("Voltar", color = buttonFgOnAccent, fontSize = (16.sp * appliedScale), fontWeight = FontWeight.SemiBold) }
-                    }
-                }
-            }
+            MotionResultScreen(
+                lastReport = lastReport,
+                history = history,
+                appliedContrast = appliedContrast,
+                appliedDark = appliedDark,
+                appliedScale = appliedScale,
+                accentSolid = accentSolid,
+                onNewTest = {
+                    sfx.play(Sfx.CLICK)
+                    selectedHand = null
+                    isDominant = null
+                    chosenMode = null
+                    testStarted = false
+                    finished = false
+                    clicks = 0
+                    missedClicks = 0
+                    timeLeft = durationSecondsWithMovement
+                },
+                onBack = { sfx.play(Sfx.CLICK); showEndDialog = true }
+            )
         }
     }
 }
@@ -638,83 +548,179 @@ private fun BigSelectButton(
     ) { Text(label, fontSize = (14.sp * appliedScale)) }
 }
 
-/* ----------------------------- Report cards ----------------------------- */
-
+/* ------------------------- Motion Result Screen ---------------------------- */
 @Composable
-private fun ReportCard(
-    report: MotionReport,
-    container: Color,
-    border: BorderStroke?,
-    titleColor: Color,
-    textPrimary: Color,
-    textSecondary: Color,
-    scale: Float
+private fun MotionResultScreen(
+    lastReport: MotionReport?,
+    history: List<MotionReport>,
+    appliedContrast: Boolean,
+    appliedDark: Boolean,
+    appliedScale: Float,
+    accentSolid: Color,
+    onNewTest: () -> Unit,
+    onBack: () -> Unit
 ) {
-    val dateStr = remember(report.date) {
-        LocalDateTime.ofInstant(report.date, ZoneId.systemDefault())
-            .format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"))
-    }
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = container),
-        elevation = CardDefaults.cardElevation(defaultElevation = if (border != null) 0.dp else 2.dp),
-        border = border,
-        shape = RoundedCornerShape(14.dp)
+    ResultDialogContainer(
+        appliedContrast = appliedContrast,
+        appliedDark = appliedDark
     ) {
-        Column(modifier = Modifier.padding(14.dp)) {
-            Text("Relatório do teste", fontSize = (18.sp * scale), color = titleColor, fontWeight = FontWeight.SemiBold)
-            Spacer(Modifier.height(8.dp))
-            Text("Data/Hora: $dateStr", fontSize = (14.sp * scale), color = textPrimary)
-            Text("Duração: ${report.secondsTotal.toInt()}s", fontSize = (14.sp * scale), color = textPrimary)
-            Text("Cliques totais: ${report.totalClicks}", fontSize = (14.sp * scale), color = textPrimary)
-            Text("Cliques por minuto: ${report.clicksPerMinute}", fontSize = (14.sp * scale), color = textPrimary)
-            Text("Cliques errados: ${report.missedClicks}", fontSize = (14.sp * scale), color = textPrimary)
-            Spacer(Modifier.height(8.dp))
-            Text("Mão usada: ${if (report.withRightHand) "Direita" else "Esquerda"}", fontSize = (14.sp * scale), color = textSecondary)
-            Text("Mão dominante: ${if (report.withMainHand) "Sim" else "Não"}", fontSize = (14.sp * scale), color = textSecondary)
-            Text("Modo: ${if (report.withMovement) "Com movimento" else "Sem movimento"}", fontSize = (14.sp * scale), color = textSecondary)
-        }
-    }
-}
+        ResultTitle(
+            text = "Resultado do Teste",
+            appliedContrast = appliedContrast,
+            appliedDark = appliedDark,
+            appliedScale = appliedScale,
+            accent = accentSolid
+        )
+        Spacer(Modifier.height(16.dp))
 
-@Composable
-private fun SmallReportRow(
-    report: MotionReport,
-    container: Color,
-    border: BorderStroke?,
-    textPrimary: Color,
-    textSecondary: Color,
-    scale: Float
-) {
-    val dateStr = remember(report.date) {
-        LocalDateTime.ofInstant(report.date, ZoneId.systemDefault())
-            .format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"))
-    }
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = container),
-        elevation = CardDefaults.cardElevation(defaultElevation = if (border != null) 0.dp else 1.dp),
-        border = border,
-        shape = RoundedCornerShape(12.dp)
-    ) {
-        Row(
-            modifier = Modifier.padding(10.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column {
-                Text("• $dateStr", fontSize = (13.sp * scale), color = textPrimary)
-                Text(
-                    "   ${report.totalClicks} cliques • ${report.clicksPerMinute} cpm • ${report.missedClicks} errados",
-                    fontSize = (13.sp * scale),
-                    color = textSecondary
+        lastReport?.let { report ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                ResultMetricCard(
+                    title = "Cliques/min",
+                    value = "${report.clicksPerMinute}",
+                    unit = "CPM",
+                    color = accentSolid,
+                    icon = Icons.Default.Speed,
+                    appliedContrast = appliedContrast,
+                    appliedDark = appliedDark,
+                    appliedScale = appliedScale
                 )
+                ResultMetricCard(
+                    title = "Total cliques",
+                    value = "${report.totalClicks}",
+                    unit = "",
+                    color = accentSolid,
+                    icon = Icons.Default.TouchApp,
+                    appliedContrast = appliedContrast,
+                    appliedDark = appliedDark,
+                    appliedScale = appliedScale
+                )
+            }
+            Spacer(Modifier.height(16.dp))
+
+            ResultSectionLabel(
+                text = "Detalhes",
+                appliedContrast = appliedContrast,
+                appliedDark = appliedDark,
+                appliedScale = appliedScale
+            )
+            Spacer(Modifier.height(8.dp))
+
+            ResultItemCard(
+                appliedContrast = appliedContrast,
+                appliedDark = appliedDark
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        ResultItemText(
+                            text = "Duração",
+                            appliedContrast = appliedContrast,
+                            appliedDark = appliedDark,
+                            appliedScale = appliedScale,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 13f
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            "${report.secondsTotal.toInt()}s",
+                            fontSize = 16.sp * appliedScale,
+                            fontWeight = FontWeight.Bold,
+                            color = accentSolid
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        ResultItemText(
+                            text = "Cliques errados",
+                            appliedContrast = appliedContrast,
+                            appliedDark = appliedDark,
+                            appliedScale = appliedScale,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 13f
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            "${report.missedClicks}",
+                            fontSize = 16.sp * appliedScale,
+                            fontWeight = FontWeight.Bold,
+                            color = accentSolid
+                        )
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+                ResultItemText(
+                    text = "Mão: ${if (report.withRightHand) "Direita" else "Esquerda"} ${if (report.withMainHand) "(Dominante)" else "(Não dominante)"}",
+                    appliedContrast = appliedContrast,
+                    appliedDark = appliedDark,
+                    appliedScale = appliedScale,
+                    fontSize = 14f
+                )
+                Spacer(Modifier.height(4.dp))
+                ResultItemText(
+                    text = "Modo: ${if (report.withMovement) "Com movimento" else "Sem movimento"}",
+                    appliedContrast = appliedContrast,
+                    appliedDark = appliedDark,
+                    appliedScale = appliedScale,
+                    fontSize = 14f
+                )
+            }
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        Button(
+            onClick = onNewTest,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = accentSolid,
+                contentColor = if (appliedContrast) Color.Black else Color.White
+            ),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Text(
+                "Novo teste",
+                color = if (appliedContrast) Color.Black else Color.White,
+                fontSize = 16.sp * appliedScale,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        if (appliedContrast) {
+            OutlinedButton(
+                onClick = onBack,
+                border = BorderStroke(2.dp, accentSolid),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = accentSolid),
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp)
+            ) {
                 Text(
-                    "   ${if (report.withRightHand) "Mão direita" else "Mão esquerda"} • " +
-                            (if (report.withMainHand) "Dominante" else "Não dominante") + " • " +
-                            (if (report.withMovement) "Com movimento" else "Sem movimento"),
-                    fontSize = (12.sp * scale),
-                    color = textSecondary
+                    "Voltar ao Início",
+                    fontSize = 16.sp * appliedScale,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        } else {
+            Button(
+                onClick = onBack,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = GreenAccent,
+                    contentColor = Color.White
+                ),
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(
+                    "Voltar ao Início",
+                    color = Color.White,
+                    fontSize = 16.sp * appliedScale,
+                    fontWeight = FontWeight.SemiBold
                 )
             }
         }

--- a/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/MotionTestScreen.kt
@@ -61,7 +61,13 @@ fun MotionTestScreen(
     onBack: () -> Unit = {}
 ) {
     val sfx = rememberSfxController()
-    BackHandler(enabled = true) { sfx.play(Sfx.CLICK); onBack() }
+
+    var showEndDialog by remember { mutableStateOf(false) }
+
+    BackHandler(enabled = true) {
+        sfx.play(Sfx.CLICK)
+        showEndDialog = true
+    }
 
     val context = LocalContext.current
     val settings: SettingsViewModel = viewModel(factory = SettingsViewModelFactory(context))
@@ -123,6 +129,73 @@ fun MotionTestScreen(
 
     fun durationFor(mode: MotionMode?) =
         if (mode == MotionMode.STATIC) durationSecondsWithoutMovement else durationSecondsWithMovement
+
+    if (showEndDialog) {
+        val container = when {
+            appliedContrast -> Color.Black
+            appliedDark -> Color(0xFF1E1E1E)
+            else -> Color.White
+        }
+        val titleColor = if (appliedContrast) accentSolid else if (appliedDark) Color.White else Color(0xFF1B1B1B)
+        val bodyColor = if (appliedContrast || appliedDark) Color.White else Color(0xFF3A3A3A)
+        val confirmContainer = when {
+            appliedContrast -> accentSolid
+            appliedDark -> GreenDark
+            else -> Color.White
+        }
+        val confirmContent = when {
+            appliedContrast -> Color.Black
+            appliedDark -> Color.White
+            else -> Color(0xFF2E7D32)
+        }
+        val dismissContent = when {
+            appliedContrast -> accentSolid
+            appliedDark -> Color(0xFF8BC34A)
+            else -> GreenDark
+        }
+
+        AlertDialog(
+            onDismissRequest = { sfx.play(Sfx.BUBBLE); showEndDialog = false },
+            containerColor = container,
+            titleContentColor = titleColor,
+            textContentColor = bodyColor,
+            confirmButton = {
+                Button(
+                    onClick = {
+                        sfx.play(Sfx.CLICK)
+                        showEndDialog = false
+                        onBack()
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = confirmContainer,
+                        contentColor = confirmContent
+                    ),
+                    shape = RoundedCornerShape(14.dp)
+                ) {
+                    Text("Sair", fontSize = 16.sp * appliedScale)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { sfx.play(Sfx.CLICK); showEndDialog = false },
+                    colors = ButtonDefaults.textButtonColors(contentColor = dismissContent)
+                ) { Text("Continuar", fontSize = 16.sp * appliedScale) }
+            },
+            title = {
+                Text("Encerrar sessão", fontWeight = FontWeight.SemiBold, fontSize = 20.sp * appliedScale)
+            },
+            text = {
+                val message = if (testStarted && !finished) {
+                    "O teste está em andamento. Se sair agora, o progresso será perdido."
+                } else if (finished) {
+                    "Deseja voltar para a tela inicial?"
+                } else {
+                    "Deseja cancelar e voltar para a tela inicial?"
+                }
+                Text(message, fontSize = 15.sp * appliedScale, lineHeight = 20.sp * appliedScale)
+            }
+        )
+    }
 
     @Suppress("UnusedBoxWithConstraintsScope")
     BoxWithConstraints(
@@ -214,7 +287,7 @@ fun MotionTestScreen(
                 horizontalArrangement = Arrangement.Start,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { sfx.play(Sfx.CLICK); onBack() }) {
+                IconButton(onClick = { sfx.play(Sfx.CLICK); showEndDialog = true }) {
                     Icon(
                         imageVector = Icons.Filled.ArrowBack,
                         contentDescription = "Voltar",
@@ -481,7 +554,7 @@ fun MotionTestScreen(
                         ) { Text("Novo teste", color = buttonFgOnAccent, fontSize = (16.sp * appliedScale), fontWeight = FontWeight.SemiBold) }
 
                         Button(
-                            onClick = { sfx.play(Sfx.CLICK); onBack() },
+                            onClick = { sfx.play(Sfx.CLICK); showEndDialog = true },
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = accentSolid,
                                 contentColor = buttonFgOnAccent

--- a/app/src/main/java/com/recuperavc/ui/main/SentenceArrangeScreen.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/SentenceArrangeScreen.kt
@@ -805,6 +805,8 @@ fun SentenceResultScreen(
         )
         Spacer(Modifier.height(8.dp))
 
+
+
         results.forEachIndexed { idx, r ->
             ResultItemCard(
                 appliedContrast = appliedContrast,

--- a/app/src/main/java/com/recuperavc/ui/main/reports/coherence/CoherenceReportSection.kt
+++ b/app/src/main/java/com/recuperavc/ui/main/reports/coherence/CoherenceReportSection.kt
@@ -193,7 +193,9 @@ fun CoherenceReportDetailDialog(
 
                 Spacer(Modifier.height(20.dp))
 
-                val sr = if (groups.isNotEmpty()) groups.count { it.tries.firstOrNull()?.correct == true }.toFloat() / groups.size.toFloat() else 0f
+                val totalTries = groups.sumOf { it.tries.size }
+                val correctTries = groups.sumOf { it.tries.count { t -> t.correct } }
+                val sr = if (totalTries > 0) correctTries.toFloat() / totalTries.toFloat() else 0f
                 Card(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(16.dp),


### PR DESCRIPTION
1. Corrigido problema do darkmode na tela de relatório de áudio;
2. Adicionado confirmação do modal de Encerrar Sessão na tela de teste de coordenação e teste de áudio corretamente ao apertar o botão de voltar nativo do celular;
3. Corrigido estilização da tela de resultado de voz nos modos de darkmode e whitemode;
4. Padronizado todas as telas de resultado de acordo com a estilização da tela de voz;
5. Adicionado a visualização das tentativas incorretas na tela de resultado de raciocínio;
6. Corrigido o cálculo da taxa de acerto na página de relatório de raciocínio;
7. Adicionado informação de clicar no botão de gravar para enviar áudio e melhorado o botão de cancelar da tela de teste de áudio;